### PR TITLE
UPDATE!

### DIFF
--- a/src/components/Announcements.jsx
+++ b/src/components/Announcements.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import "../styles/Settings.css";
 import config from "../config.js";
 
-const serverURL = "https://node-js-api.glitch.me/";
+const serverURL = "https://lc-bell-schedule-api.glitch.me/";
 
 // import calendar from "../icalfeed.json"
 import "../styles/DateCountdown.css";

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -345,7 +345,7 @@ export default class Settings extends React.Component {
         <div style={{ clear: "both" }}></div>
         <div className="settings-page">{this.renderPage()}</div>
         <span className="version">
-          Ver. 2.2.1 (Fresh New Content) |{" "}
+          Ver. 2.2.2 (UPDATE) |{" "}
           {/*version number last updated on 12/15/22*/}
           <a href="https://github.com/ABUCKY0/bell-countdown/issues/new">Report Bugs</a> |{" "}
           <a href="https://github.com/ABUCKY0/bell-countdown">Github</a>

--- a/src/styles/Announcements.css
+++ b/src/styles/Announcements.css
@@ -5,7 +5,7 @@
 }
 
 div.announcements {
-  background-color: #90ee9077;
+  background-color: #222222;
   box-sizing: border-box;
   font-family: sans-serif;
   margin: 3vh;
@@ -14,7 +14,7 @@ div.announcements {
   border-radius: 10px;
   min-width: 96vw;
 
-  color: darkgreen;
+  color: red;
 }
 /*
       .announcements {
@@ -43,11 +43,12 @@ div.announcements {
   padding: 0.2rem;
   margin: 2px;
   place-items: left;
-  border: 2px lightgray solid;
+  /*border: 2px white solid;*/
   border-radius: 2rem;
-  background-color: #ff000077;
+  background-color: #333333;
+  font-weight:bold;
   height: 2rem;
   font-size: 1rem;
-  color: white;
+  color: red;
 }
 /*d*/


### PR DESCRIPTION
 - Removed Christmas Styling (What, Christmas is Over) 
 - Fixed Issues with the Announcements Tab 
 - Replaced the link to the bell schedule on the main page to an individual page at the top bar. 
 - Reverted to normal schedules.